### PR TITLE
Patch 1

### DIFF
--- a/Adafruit_BLE_UART.cpp
+++ b/Adafruit_BLE_UART.cpp
@@ -271,7 +271,7 @@ size_t Adafruit_BLE_UART::write(uint8_t * buffer, uint8_t len)
 
     //delay(35); // required delay between sends -- NBP (2/21/2015) not needed with credit check fix
 
-    if(!(len -= bytesThisPass)) break;
+    len -= bytesThisPass; // NBP (2/22/2015) fix for return value, no break, also fixes println()
     sent += bytesThisPass;
   }
 

--- a/Adafruit_BLE_UART.h
+++ b/Adafruit_BLE_UART.h
@@ -27,7 +27,7 @@ All text above, and the splash screen below must be included in any redistributi
 
 #include "utility/aci_evts.h"
 
-#define BLE_RW_DEBUG
+//#define BLE_RW_DEBUG
 
 extern "C" 
 {


### PR DESCRIPTION
Fix pipe errors on write() -- error 0x91-- credit tracking fixes
Removed delay(35) in write() -- not needed with credit checking
Fix write(buffer,len) return code -- fixes println()
Turned off BLE_RW_DEBUG