### PR TITLE
Updated Spi implementation to use conflict free "SpiSettings" bus configuration

### DIFF
--- a/utility/hal_aci_tl.cpp
+++ b/utility/hal_aci_tl.cpp
@@ -274,10 +274,13 @@ void hal_aci_tl_init()
 {
   received_data.buffer[0] = 0;
 
+  //SPISettings NRF8001BLE_SPIconfig(1000000, LSBFIRST, SPI_MODE0); 
+  
   SPI.begin();
-  SPI.setBitOrder(LSBFIRST);
-  SPI.setClockDivider(SPI_CLOCK_DIV8);
-  SPI.setDataMode(SPI_MODE0);
+  
+  //SPI.setBitOrder(LSBFIRST);
+  //SPI.setClockDivider(SPI_CLOCK_DIV8);
+  //SPI.setDataMode(SPI_MODE0);
 
 
   
@@ -311,7 +314,8 @@ void hal_aci_tl_init()
   }
 
   delay(30); //Wait for the nRF8001 to get hold of its lines - the lines float for a few ms after the reset
-  if (HAL_IO_RADIO_IRQ != 0xFF) 
+  if (HAL_IO_RADIO_IRQ != 0xFF)
+    SPI.usingInterrupt(HAL_IO_RADIO_IRQ); // add checking for spi conflicts
     attachInterrupt(HAL_IO_RADIO_IRQ, m_rdy_line_handle, LOW); 
   // We use the LOW level of the RDYN line as the atmega328 can wakeup from sleep only on LOW
 }
@@ -354,7 +358,7 @@ hal_aci_data_t * hal_aci_tl_poll_get(void)
 
 
   //SPI.begin();  
-    
+  SPI.beginTransaction(SPISettings(1000000, LSBFIRST, SPI_MODE0));  // gain control of SPI bus
   HAL_IO_SET_STATE(HAL_IO_RADIO_REQN, 0);
   
   // Receive from queue
@@ -395,6 +399,7 @@ hal_aci_data_t * hal_aci_tl_poll_get(void)
   }
 
   HAL_IO_SET_STATE(HAL_IO_RADIO_REQN, 1);
+  SPI.endTransaction();              // release the SPI bus
   //SPI.end()
   //RDYN should follow the REQN line in approx 100ns
   

--- a/utility/hal_aci_tl.cpp
+++ b/utility/hal_aci_tl.cpp
@@ -274,7 +274,6 @@ void hal_aci_tl_init()
 {
   received_data.buffer[0] = 0;
 
-  //SPISettings NRF8001BLE_SPIconfig(1000000, LSBFIRST, SPI_MODE0); 
   
   SPI.begin();
   
@@ -358,7 +357,7 @@ hal_aci_data_t * hal_aci_tl_poll_get(void)
 
 
   //SPI.begin();  
-  SPI.beginTransaction(SPISettings(1000000, LSBFIRST, SPI_MODE0));  // gain control of SPI bus
+  SPI.beginTransaction(SPISettings(2000000, LSBFIRST, SPI_MODE0));  // gain control of SPI bus
   HAL_IO_SET_STATE(HAL_IO_RADIO_REQN, 0);
   
   // Receive from queue


### PR DESCRIPTION
Spi implementation has been updated to eliminate Spi conflicts by using the recent "SPISettings" implementation of the Arduino SPi library.
Library now plays nice with other SPI Arduino libraries that use this method and is processor clock speed independent as well. (Spi speed for nRF ic is now always 2 mhz )
