### PR TITLE
Add timeout option to write().

### DIFF
--- a/Adafruit_BLE_UART.cpp
+++ b/Adafruit_BLE_UART.cpp
@@ -232,9 +232,10 @@ size_t Adafruit_BLE_UART::print(const __FlashStringHelper *ifsh)
   return written;
 }
 
-size_t Adafruit_BLE_UART::write(uint8_t * buffer, uint8_t len)
+size_t Adafruit_BLE_UART::write(uint8_t * buffer, uint8_t len, uint16_t timeout)
 {
   uint8_t bytesThisPass, sent = 0;
+  uint16_t timer = 0;
 
 #ifdef BLE_RW_DEBUG
   Serial.print(F("\tWriting out to BTLE:"));
@@ -252,6 +253,15 @@ size_t Adafruit_BLE_UART::write(uint8_t * buffer, uint8_t len)
     if(!lib_aci_is_pipe_available(&aci_state, PIPE_UART_OVER_BTLE_UART_TX_TX))
     {
       pollACI();
+      
+      if (timeout != 0) {
+        timer += 10;
+	    if (timer > timeout) {
+		  return sent;
+	    }
+	    delay(10);
+      }
+      
       continue;
     }
 

--- a/Adafruit_BLE_UART.h
+++ b/Adafruit_BLE_UART.h
@@ -44,7 +44,7 @@ class Adafruit_BLE_UART : public Stream
   
   bool begin   ( uint16_t advTimeout = 0, uint16_t advInterval = 80 );
   void pollACI ( void );
-  size_t write ( uint8_t * buffer, uint8_t len );
+  size_t write ( uint8_t * buffer, uint8_t len, uint16_t timeout = 0 );
   size_t write ( uint8_t buffer);
 
   size_t println(const char * thestr);


### PR DESCRIPTION
This change borrows from the Adafruit_PN532 library to add a timeout to the write() call.  If the timeout is activated, the write() call still returns the actual number of bytes sent.  The default is no timeout to ensure compatibility with existing code.