### PR TITLE
Fix issue with setDeviceName() not copying null terminator of string.

### DIFF
--- a/Adafruit_BLE_UART.cpp
+++ b/Adafruit_BLE_UART.cpp
@@ -301,7 +301,7 @@ void Adafruit_BLE_UART::setDeviceName(const char * deviceName)
   }
   else
   {
-    memcpy(device_name, deviceName, strlen(deviceName));
+    memcpy(device_name, deviceName, strlen(deviceName)+1);
   }
 }
 


### PR DESCRIPTION
This meant if a longer device name was previously set, then a shorter one, the end of the previous device name would still be visible. Copying 1 byte more than "strlen()" ensures the null terminator is in place, fixing the issue.