### PR TITLE
Properly override Stream multi-byte write() method

### DIFF
--- a/Adafruit_BLE_UART.cpp
+++ b/Adafruit_BLE_UART.cpp
@@ -234,7 +234,7 @@ size_t Adafruit_BLE_UART::print(const __FlashStringHelper *ifsh)
   return written;
 }
 
-size_t Adafruit_BLE_UART::write(uint8_t * buffer, uint8_t len)
+size_t Adafruit_BLE_UART::write(const uint8_t * buffer, size_t len)
 {
   uint8_t bytesThisPass, sent = 0;
 
@@ -264,7 +264,7 @@ size_t Adafruit_BLE_UART::write(uint8_t * buffer, uint8_t len)
       continue;
     }
 
-    lib_aci_send_data(PIPE_UART_OVER_BTLE_UART_TX_TX, &buffer[sent],
+    lib_aci_send_data(PIPE_UART_OVER_BTLE_UART_TX_TX, (uint8_t*)&buffer[sent],
       bytesThisPass);
     aci_state.data_credit_available--;
 

--- a/Adafruit_BLE_UART.h
+++ b/Adafruit_BLE_UART.h
@@ -44,8 +44,8 @@ class Adafruit_BLE_UART : public Stream
   
   bool begin   ( uint16_t advTimeout = 0, uint16_t advInterval = 80 );
   void pollACI ( void );
-  size_t write ( uint8_t * buffer, uint8_t len );
-  size_t write ( uint8_t buffer);
+  size_t write ( const uint8_t * buffer, size_t len ) override;
+  size_t write ( uint8_t buffer) override;
 
   size_t println(const char * thestr);
   size_t print(const char * thestr);
@@ -58,10 +58,10 @@ class Adafruit_BLE_UART : public Stream
   void setDeviceName(const char * deviceName);
 
   // Stream compatibility
-  int available(void);
-  int read(void);
-  int peek(void);
-  void flush(void);
+  int available(void) override;
+  int read(void) override;
+  int peek(void) override;
+  void flush(void) override;
 
   aci_evt_opcode_t getState(void);
 


### PR DESCRIPTION
Previously, the write() method for uint8_t buffers didn't quite have the
right signature to override the method in the Stream class, which made
it impossible to call from a Stream pointer.

Also, C++11 override keywords were added to make overriding Stream
methods more explicit and compiler-checked.

Thank you for creating a pull request to contribute to Adafruit's GitHub code!
Before you open the request please review the following guidelines and tips to
help it be more easily integrated:

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

- **Describe any known limitations with your change.**  For example if the change
  doesn't apply to a supported platform of the library please mention it.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

Thank you again for contributing!  We will try to test and integrate the change
as soon as we can, but be aware we have many GitHub repositories to manage and
can't immediately respond to every request.  There is no need to bump or check in
on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated--sometimes the
priorities of Adafruit's GitHub code (education, ease of use) might not match the
priorities of the pull request.  Don't fret, the open source community thrives on
forks and GitHub makes it easy to keep your changes in a forked repo.

After reviewing the guidelines above you can delete this text from the pull request.
