### PR TITLE
Add support for Atmega644P when used with Bobuino pinout of MightyCore.

### DIFF
--- a/utility/hal_aci_tl.cpp
+++ b/utility/hal_aci_tl.cpp
@@ -74,6 +74,11 @@ static const uint8_t dreqinttable[] = {
   14, 5,
   7,  6,
   18, 7,
+  // Add support for ATmega644 using the bobuino pinout via MightyCore lib
+#elif  defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)
+  6,  2,
+  2,  0,
+  3,  1,
 #endif
 };
 


### PR DESCRIPTION
This is just a single file change to add support for the Atmega644p.  
It only modifies hal_acl_tl.cpp for users with  either of these defined:

defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)

So the scope is pretty small.
I've only tested this on the pin 6 INT2 version for my board
using MightyCore's:

Board: Atmega644 
Variant: 644P/644PA
Pinout: Bobuino

I can confirm that it works.  
Pin 2 INT0 and Pin 3 INT1 are just based on the data sheet, and should also work, but I have not tested them directly.

